### PR TITLE
Use the New Official Swift Multi-Arch Docker Images

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,7 +29,7 @@ jobs:
     name: Linux ARM WebService
     runs-on: ARM64
     container:
-      image: ghcr.io/apodini/swift@sha256:53b4295f95dc1eafcbc2e03c5dee41839e9652ca31397b9feb4d8903fe1b54ea
+      image: swiftlang/swift:nightly-focal
     defaults:
       run:
         working-directory: ./WebService

--- a/WebService/Dockerfile
+++ b/WebService/Dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM ghcr.io/apodini/swift@sha256:53b4295f95dc1eafcbc2e03c5dee41839e9652ca31397b9feb4d8903fe1b54ea as build
+FROM swiftlang/swift:nightly-focal as build
 
 # Install OS updates and, if needed, sqlite3
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
@@ -35,7 +35,7 @@ RUN [ -d "$(swift build --package-path /build/WebService --show-bin-path)/WebSer
 # ================================
 # Run image
 # ================================
-FROM ghcr.io/apodini/swift@sha256:53b4295f95dc1eafcbc2e03c5dee41839e9652ca31397b9feb4d8903fe1b54ea as run
+FROM swiftlang/swift:nightly-focal as run
 
 # Make sure all system packages are up to date.
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \


### PR DESCRIPTION
The Swift project just started publishing multi-architecture docker images at swiftlang/swift:nightly-focal. This PR tests if they work for us as well.
@Lerbert might make the project even easier as we don't have to rely on the custom build ones that I build myself.
CC @hendesi 